### PR TITLE
feat: Use `NLog.Layouts.Layout<T>` to capture TraceId and SpanId

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ To use the NLog target, follow these steps:
        <extensions>
            <add assembly="hangy.NLog.Targets.ApplicationInsights" />
        </extensions>
-       <targets>
-           <target xsi:type="ApplicationInsightsTarget" name="aiTarget" includeActivity="true">
+       <targets async="true">
+           <target xsi:type="ApplicationInsightsTarget" name="aiTarget">
                <connectionString>Your_ApplicationInsights_ConnectionString</connectionString> <!-- Only required if not using ApplicationInsights.config -->
                <contextproperty name="threadid" layout="${threadid}" /> <!-- Can be repeated with more context -->
            </target>
@@ -30,4 +30,11 @@ To use the NLog target, follow these steps:
 
 1. Complex objects are flattened when written to `customDimensions`. [#8](https://github.com/hangy/NLog.Targets.ApplicationInsights/issues/8)
 1. Properties with the same name are overwritten. For example, if you have a GDC value named `Name`, and a log event property of the same name, the GDC value will be logged. [#10](https://github.com/hangy/NLog.Targets.ApplicationInsights/issues/10)
-1. `includeActivity=true` (default: `false`) will _not_ work as expected if the target is wrapped in an asynchronous target wrapper (ie. using `<targets async="true">` du to the `Activity` being scoped to a thread.
+
+## Activity Tracing
+
+By default, the ApplicationInsightsTarget logs the trace and span information from the current. If you want to disable this behaviour, set the layout as follows:
+
+```xml
+<target xsi:type="ApplicationInsightsTarget" name="aiTarget" spanId="" traceId="">
+```

--- a/test/NLogTarget.Tests/NLogTargetTests.cs
+++ b/test/NLogTarget.Tests/NLogTargetTests.cs
@@ -541,7 +541,7 @@
 
             try
             {
-                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", includeActivity: true);
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/");
                 aiLogger.Info("Info message");
 
                 var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
@@ -566,13 +566,113 @@
 
             try
             {
-                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", includeActivity: true);
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/");
                 aiLogger.Error("Error Message");
 
                 var telemetry = this.adapterHelper.Channel.SentItems.FirstOrDefault() as TraceTelemetry;
                 Assert.AreEqual("Error Message", telemetry.Message);
                 Assert.AreEqual(activity.TraceId.ToString(), telemetry.Context.Operation.Id);
                 Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
+            }
+            finally
+            {
+                Activity.Current = originalActivity;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogInfoDoesNotContainTraceIdIfLayoutIsEmpty()
+        {
+            Activity activity = new(nameof(NLogInfoDoesNotContainTraceIdIfLayoutIsEmpty));
+            activity.Start();
+            var originalActivity = Activity.Current;
+            Activity.Current = activity;
+
+            try
+            {
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", traceIdLayout: string.Empty);
+                aiLogger.Info("Info message");
+
+                var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
+                Assert.AreEqual($"Info message", telemetry.Message);
+                Assert.IsTrue(string.IsNullOrWhiteSpace(telemetry.Context.Operation.Id));
+                Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
+            }
+            finally
+            {
+                Activity.Current = originalActivity;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogErrorDoesNotContainTraceIdIfLayoutIsEmpty()
+        {
+            Activity activity = new(nameof(NLogErrorDoesNotContainTraceIdIfLayoutIsEmpty));
+            activity.Start();
+            var originalActivity = Activity.Current;
+            Activity.Current = activity;
+
+            try
+            {
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", traceIdLayout: string.Empty);
+                aiLogger.Error("Error Message");
+
+                var telemetry = this.adapterHelper.Channel.SentItems.FirstOrDefault() as TraceTelemetry;
+                Assert.AreEqual("Error Message", telemetry.Message);
+                Assert.IsTrue(string.IsNullOrWhiteSpace(telemetry.Context.Operation.Id));
+                Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
+            }
+            finally
+            {
+                Activity.Current = originalActivity;
+            }
+        }        
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogInfoDoesNotContainSpanIdIfLayoutIsEmpty()
+        {
+            Activity activity = new(nameof(NLogInfoDoesNotContainSpanIdIfLayoutIsEmpty));
+            activity.Start();
+            var originalActivity = Activity.Current;
+            Activity.Current = activity;
+
+            try
+            {
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", spanIdLayout: string.Empty);
+                aiLogger.Info("Info message");
+
+                var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
+                Assert.AreEqual($"Info message", telemetry.Message);
+                Assert.AreEqual(activity.TraceId.ToString(), telemetry.Context.Operation.Id);
+                Assert.IsTrue(string.IsNullOrWhiteSpace(telemetry.Context.Operation.ParentId));
+            }
+            finally
+            {
+                Activity.Current = originalActivity;
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogErrorDoesNotContainSpanIdIfLayoutIsEmpty()
+        {
+            Activity activity = new(nameof(NLogErrorDoesNotContainSpanIdIfLayoutIsEmpty));
+            activity.Start();
+            var originalActivity = Activity.Current;
+            Activity.Current = activity;
+
+            try
+            {
+                var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", spanIdLayout: string.Empty);
+                aiLogger.Error("Error Message");
+
+                var telemetry = this.adapterHelper.Channel.SentItems.FirstOrDefault() as TraceTelemetry;
+                Assert.AreEqual("Error Message", telemetry.Message);
+                Assert.AreEqual(activity.TraceId.ToString(), telemetry.Context.Operation.Id);
+                Assert.IsTrue(string.IsNullOrWhiteSpace(telemetry.Context.Operation.ParentId));
             }
             finally
             {
@@ -591,8 +691,9 @@
 
             try
             {
-                var aiLogger = this.CreateAsyncTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", includeActivity: true);
+                var aiLogger = this.CreateAsyncTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/");
                 aiLogger.Info("Info message");
+                aiLogger.Factory.Flush();
 
                 var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
                 Assert.AreEqual($"Info message", telemetry.Message);
@@ -616,8 +717,9 @@
 
             try
             {
-                var aiLogger = this.CreateAsyncTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/", includeActivity: true);
+                var aiLogger = this.CreateAsyncTargetWithGivenConnectionString("InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/");
                 aiLogger.Error("Error Message");
+                aiLogger.Factory.Flush();
 
                 var telemetry = this.adapterHelper.Channel.SentItems.FirstOrDefault() as TraceTelemetry;
                 Assert.AreEqual("Error Message", telemetry.Message);
@@ -646,7 +748,8 @@
             string connectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/",
             Action<Logger> loggerAction = null,
             ApplicationInsightsTarget target = null,
-            bool includeActivity = false)
+            string traceIdLayout = null,
+            string spanIdLayout = null)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope - Caller is responsible for disposal
             target ??= new ApplicationInsightsTarget();
@@ -655,7 +758,15 @@
             target.TelemetryConfigurationFactory = () => new TelemetryConfiguration() { TelemetryChannel = this.adapterHelper.Channel };
 
             target.ConnectionString = connectionString;
-            target.IncludeActivity = includeActivity;
+            if (traceIdLayout != null)
+            {
+                target.TraceId = traceIdLayout;
+            }
+
+            if (spanIdLayout != null)
+            {
+                target.SpanId = spanIdLayout;
+            }
 
             var rule = new LoggingRule("*", LogLevel.Trace, target);
             var config = new LoggingConfiguration();
@@ -683,7 +794,8 @@
             string connectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;IngestionEndpoint=https://westeurope.in.applicationinsights.azure.example.com/;LiveEndpoint=https://westeurope.livediagnostics.monitor.azure.example.com/",
             Action<Logger> loggerAction = null,
             ApplicationInsightsTarget target = null,
-            bool includeActivity = false)
+            string traceIdLayout = null,
+            string spanIdLayout = null)
         {
 #pragma warning disable CA2000 // Dispose objects before losing scope - Caller is responsible for disposal
             target ??= new ApplicationInsightsTarget();
@@ -692,7 +804,15 @@
             target.TelemetryConfigurationFactory = () => new TelemetryConfiguration() { TelemetryChannel = this.adapterHelper.Channel };
 
             target.ConnectionString = connectionString;
-            target.IncludeActivity = includeActivity;
+            if (traceIdLayout != null)
+            {
+                target.TraceId = traceIdLayout;
+            }
+
+            if (spanIdLayout != null)
+            {
+                target.SpanId = spanIdLayout;
+            }
 
 #pragma warning disable CA2000 // Dispose objects before losing scope - Caller is responsible for disposal
             var asyncWrapper = new AsyncTargetWrapper


### PR DESCRIPTION
This enables the activity tracing information to be captured even when using an async target wrapper.

Closes #52